### PR TITLE
Add nerdctl install tasks in container-runtime role

### DIFF
--- a/playbooks/roles/container-runtime/defaults/main.yaml
+++ b/playbooks/roles/container-runtime/defaults/main.yaml
@@ -1,3 +1,4 @@
 containerd_version: 1.6.25
 runc_version: 1.1.10
 cni_plugins_version: 1.3.0
+nerdctl_version: 1.7.2

--- a/playbooks/roles/container-runtime/tasks/main.yaml
+++ b/playbooks/roles/container-runtime/tasks/main.yaml
@@ -95,6 +95,19 @@
     remote_src: yes
     extra_opts: [--strip-component=1]
 
+- name: nerdctl 파일 다운로드
+  get_url:
+    url: "https://github.com/containerd/nerdctl/releases/download/v{{ nerdctl_version }}/nerdctl-{{ nerdctl_version }}-linux-{{ host_architecture }}.tar.gz"
+    dest: "/tmp/nerdctl-{{ nerdctl_version }}-linux-{{ host_architecture }}.tar.gz"
+    mode: 0644
+
+- name: nerdctl 압축 해제 및 /usr/local/bin 이동
+  unarchive:
+    src: "/tmp/nerdctl-{{ nerdctl_version }}-linux-{{ host_architecture }}.tar.gz"
+    dest: /usr/local/bin
+    remote_src: yes
+
+
 - name: PATH 환경 변수에 /usr/local/bin 추가
   lineinfile:
     path: /etc/profile


### PR DESCRIPTION
nerdctl 툴을 기본적으로 모든 노드 (컨트롤플레인, 워커노드) 에 추가합니다.